### PR TITLE
Update Helm chart dependencies and add service account support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -24,12 +24,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4.3.0
         with:
-          version: v3.8.1
+          version: v3.8.2
           # charts_repo_url: "https://helm.78financials.ng"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -44,5 +44,9 @@ helm template payaza charts/payaza/ --values charts/payaza/values.yaml
 ```
 
 ```bash
+helm template payaza charts/payaza-v2/ --values charts/payaza-v2/values.yaml
+```
+
+```bash
 helm upgrade --install nginx charts/payaza/ --values charts/payaza/values.yaml
 ```

--- a/charts/payaza-v2/Chart.yaml
+++ b/charts/payaza-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: payaza-v2
-description: quoted deployment version number
+description: Introduced service account support for deployments access to AWS resources.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/payaza-v2/templates/deployment.yaml
+++ b/charts/payaza-v2/templates/deployment.yaml
@@ -16,11 +16,14 @@ spec:
         app: {{ .Values.deployment.name | quote }}
         serverless: {{ .Values.labels.serverless | quote }}
         {{- if .Values.deployment.blueGreen }}
-        version: {{ .Values.deployment.blue }}            
+        version: {{ .Values.deployment.blue }}
         {{- else }}
         version: {{ .Values.deployment.tag | quote}}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enable }}
+      serviceAccountName: {{ .Values.serviceAccount.name | quote }}
+      {{- end }}
       containers:
         - name: {{ .Values.deployment.name | quote }}
           {{- if .Values.deployment.blueGreen }}

--- a/charts/payaza-v2/values.yaml
+++ b/charts/payaza-v2/values.yaml
@@ -68,6 +68,11 @@ service:
   annotations:
     enabled: false # Set as `true` for apis that uses http/2
 
+# service account
+serviceAccount:
+  enable: false # Set to `true` to create a service account
+  name: "" # Name of the service account. If not set, it will be auto-generated.
+
 # Environment Variables sources
 env:
   secret:


### PR DESCRIPTION
- Upgrade actions/checkout to v4
- Upgrade azure/setup-helm to v4.3.0 and set version to v3.8.2
- Upgrade helm/chart-releaser-action to v1.7.0
- Update payaza-v2 chart description and version to 1.0.0
- Add service account configuration to values.yaml and deployment.yaml
- Add example command for payaza-v2 in README.md