### PR TITLE
Add initial Helm chart for payaza-controller with RBAC, CRDs, and metrics support

### DIFF
--- a/charts/payaza-operator/.helmignore
+++ b/charts/payaza-operator/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building Helm packages.
+# Operating system files
+.DS_Store
+
+# Version control directories
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+
+# Backup and temporary files
+*.swp
+*.tmp
+*.bak
+*.orig
+*~
+
+# IDE and editor-related files
+.idea/
+.vscode/
+
+# Helm chart artifacts
+dist/chart/*.tgz

--- a/charts/payaza-operator/Chart.yaml
+++ b/charts/payaza-operator/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: payaza-controller
+description: A Helm chart to distribute the project payaza-controller
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+icon: "https://payaza.africa/favicon.ico"

--- a/charts/payaza-operator/templates/_helpers.tpl
+++ b/charts/payaza-operator/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{- define "chart.name" -}}
+{{- if .Chart }}
+  {{- if .Chart.Name }}
+    {{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+  {{- else if .Values.nameOverride }}
+    {{ .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    payaza-controller
+  {{- end }}
+{{- else }}
+  payaza-controller
+{{- end }}
+{{- end }}
+
+
+{{- define "chart.labels" -}}
+{{- if .Chart.AppVersion -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Chart.Version }}
+helm.sh/chart: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{- define "chart.hasMutatingWebhooks" -}}
+{{- $hasMutating := false }}
+{{- range . }}
+  {{- if eq .type "mutating" }}
+    $hasMutating = true }}{{- end }}
+{{- end }}
+{{ $hasMutating }}}}{{- end }}
+
+
+{{- define "chart.hasValidatingWebhooks" -}}
+{{- $hasValidating := false }}
+{{- range . }}
+  {{- if eq .type "validating" }}
+    $hasValidating = true }}{{- end }}
+{{- end }}
+{{ $hasValidating }}}}{{- end }}

--- a/charts/payaza-operator/templates/certmanager/certificate.yaml
+++ b/charts/payaza-operator/templates/certmanager/certificate.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.certmanager.enable }}
+# Self-signed Issuer
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- if .Values.metrics.enable }}
+---
+# Certificate for the metrics
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: metrics-certs
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+    - payaza-controller.{{ .Release.Namespace }}.svc
+    - payaza-controller.{{ .Release.Namespace }}.svc.cluster.local
+    - payaza-controller-metrics-service.{{ .Release.Namespace }}.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert
+{{- end }}
+{{- end }}

--- a/charts/payaza-operator/templates/crd/apps.payaza.africa_payazaservices.yaml
+++ b/charts/payaza-operator/templates/crd/apps.payaza.africa_payazaservices.yaml
@@ -1,0 +1,348 @@
+{{- if .Values.crd.enable }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: payazaservices.apps.payaza.africa
+spec:
+  group: apps.payaza.africa
+  names:
+    kind: PayazaService
+    listKind: PayazaServiceList
+    plural: payazaservices
+    singular: payazaservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Docker image
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: Desired number of replicas
+      jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    - description: Number of ready replicas
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: PayazaService is the Schema for the payazaservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PayazaServiceSpec defines the desired state of PayazaService
+            properties:
+              additionalLabels:
+                additionalProperties:
+                  type: string
+                description: AdditionalLabels are labels to add to all created resources
+                  (Deployment, Service, etc.).
+                type: object
+              additionalSecrets:
+                description: |-
+                  AdditionalSecrets are names of existing Kubernetes Secrets in the cluster that the microservice needs access to.
+                  These secrets are not mounted as volumes or environment variables by default through this field,
+                  but can be referenced by the controller logic for other purposes (e.g., imagePullSecrets, or specific init container logic).
+                items:
+                  type: string
+                type: array
+              autoscaling:
+                description: Autoscaling defines the Horizontal Pod Autoscaler configuration.
+                properties:
+                  maxReplicas:
+                    description: MaxReplicas is the upper limit for the number of
+                      replicas that can be set by the HPA.
+                    format: int32
+                    type: integer
+                  minReplicas:
+                    description: MinReplicas is the lower limit for the number of
+                      replicas that can be set by the HPA.
+                    format: int32
+                    type: integer
+                  targetCPUUtilizationPercentage:
+                    description: TargetCPUUtilizationPercentage is the target CPU
+                      utilization percentage for the HPA.
+                    format: int32
+                    type: integer
+                  targetMemoryUtilizationPercentage:
+                    description: TargetMemoryUtilizationPercentage is the target Memory
+                      utilization percentage for the HPA.
+                    format: int32
+                    type: integer
+                required:
+                - maxReplicas
+                - minReplicas
+                type: object
+              configMaps:
+                description: ConfigMaps are references to Kubernetes ConfigMaps whose
+                  keys should be mounted as environment variables.
+                items:
+                  description: ConfigMapEnvSource selects a key of a ConfigMap to
+                    be used as an environment variable.
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  type: object
+                type: array
+              containerPort:
+                description: ContainerPort is the port that the application inside
+                  the container listens on.
+                format: int32
+                type: integer
+              env:
+                description: Env is a list of environment variables to set in the
+                  container.
+                items:
+                  description: EnvVar represents an environment variable.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      description: ValueFrom determines the value of the environment
+                        variable from a source.
+                      properties:
+                        configMapKeyRef:
+                          description: ConfigMapEnvSource selects a key of a ConfigMap
+                            to be used as an environment variable.
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        secretKeyRef:
+                          description: SecretEnvSource selects a key of a Secret to
+                            be used as an environment variable.
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                description: Image is the Docker image to deploy (e.g., "my-app:latest").
+                type: string
+              ingress:
+                description: Ingress defines the ingress rules for accessing the service
+                  from outside the cluster.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations are additional annotations to add to
+                      the Ingress.
+                    type: object
+                  host:
+                    description: Host is the hostname to use for the Ingress.
+                    type: string
+                  path:
+                    default: /
+                    description: Path is the URL path for the Ingress. Defaults to
+                      "/".
+                    type: string
+                  tls:
+                    description: TLS indicates whether TLS should be enabled for this
+                      Ingress.
+                    type: boolean
+                  tlsSecretName:
+                    description: TLSSecretName is the name of the Kubernetes Secret
+                      containing the TLS certificate.
+                    type: string
+                required:
+                - host
+                type: object
+              replicas:
+                description: Replicas is the number of desired pods.
+                format: int32
+                type: integer
+              resources:
+                description: Resources defines the compute resources (CPU and memory)
+                  required by this container.
+                properties:
+                  limits:
+                    additionalProperties:
+                      type: string
+                    description: Limits describes the maximum amount of compute resources
+                      allowed.
+                    type: object
+                  requests:
+                    additionalProperties:
+                      type: string
+                    description: Requests describes the minimum amount of compute
+                      resources required.
+                    type: object
+                type: object
+              secrets:
+                description: Secrets are references to Kubernetes Secrets whose keys
+                  should be mounted as environment variables.
+                items:
+                  description: SecretEnvSource selects a key of a Secret to be used
+                    as an environment variable.
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  type: object
+                type: array
+              serviceAccountName:
+                description: ServiceAccountName is the name of the ServiceAccount
+                  to use for the pod.
+                type: string
+              serviceType:
+                default: ClusterIP
+                description: |-
+                  ServiceType defines the type of Kubernetes Service to create (e.g., ClusterIP, NodePort, LoadBalancer).
+                  Defaults to ClusterIP if not specified.
+                type: string
+            required:
+            - containerPort
+            - image
+            - replicas
+            type: object
+          status:
+            description: PayazaServiceStatus defines the observed state of PayazaService
+            properties:
+              conditions:
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make generate" to regenerate code after modifying this file
+                  Conditions represent the latest available observations of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              deploymentName:
+                description: DeploymentName is the name of the Deployment created
+                  by this operator.
+                type: string
+              hpaName:
+                description: HpaName is the name of the HorizontalPodAutoscaler created
+                  by this operator (if any).
+                type: string
+              ingressName:
+                description: IngressName is the name of the Ingress created by this
+                  operator (if any).
+                type: string
+              readyReplicas:
+                description: ReadyReplicas is the number of ready replicas observed
+                  for the deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the current number of replicas observed for
+                  the deployment.
+                format: int32
+                type: integer
+              serviceName:
+                description: ServiceName is the name of the Service created by this
+                  operator.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end -}}

--- a/charts/payaza-operator/templates/manager/manager.yaml
+++ b/charts/payaza-operator/templates/manager/manager.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payaza-controller-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
+spec:
+  replicas:  {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        {{- include "chart.labels" . | nindent 8 }}
+        control-plane: controller-manager
+        {{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}
+        {{- range $key, $value := .Values.controllerManager.pod.labels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
+    spec:
+      containers:
+        - name: manager
+          args:
+            {{- range .Values.controllerManager.container.args }}
+            - {{ . }}
+            {{- end }}
+          command:
+            - /manager
+          image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
+          {{- if .Values.controllerManager.container.env }}
+          env:
+            {{- range $key, $value := .Values.controllerManager.container.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.controllerManager.container.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.controllerManager.container.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.controllerManager.container.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.controllerManager.container.securityContext | nindent 12 }}
+          {{- if and .Values.certmanager.enable .Values.metrics.enable }}
+          volumeMounts:
+            {{- if and .Values.metrics.enable .Values.certmanager.enable }}
+            - name: metrics-certs
+              mountPath: /tmp/k8s-metrics-server/metrics-certs
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      securityContext:
+        {{- toYaml .Values.controllerManager.securityContext | nindent 8 }}
+      serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}
+      terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
+      {{- if and .Values.certmanager.enable .Values.metrics.enable }}
+      volumes:
+        {{- if and .Values.metrics.enable .Values.certmanager.enable }}
+        - name: metrics-certs
+          secret:
+            secretName: metrics-server-cert
+        {{- end }}
+      {{- end }}

--- a/charts/payaza-operator/templates/metrics/metrics-service.yaml
+++ b/charts/payaza-operator/templates/metrics/metrics-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: payaza-controller-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
+spec:
+  ports:
+    - port: 8443
+      targetPort: 8443
+      protocol: TCP
+      name: https
+  selector:
+    control-plane: controller-manager
+{{- end }}

--- a/charts/payaza-operator/templates/network-policy/allow-metrics-traffic.yaml
+++ b/charts/payaza-operator/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enable }}
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gather data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: allow-metrics-traffic
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: payaza-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP
+{{- end -}}

--- a/charts/payaza-operator/templates/prometheus/monitor.yaml
+++ b/charts/payaza-operator/templates/prometheus/monitor.yaml
@@ -1,0 +1,40 @@
+# To integrate with Prometheus.
+{{- if .Values.prometheus.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  name: payaza-controller-controller-manager-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        {{- if .Values.certmanager.enable }}
+        serverName: payaza-controller-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+        # Apply secure TLS configuration with cert-manager
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key
+        {{- else }}
+        # Development/Test mode (insecure configuration)
+        insecureSkipVerify: true
+        {{- end }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+{{- end }}

--- a/charts/payaza-operator/templates/rbac/leader_election_role.yaml
+++ b/charts/payaza-operator/templates/rbac/leader_election_role.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.enable }}
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  name: payaza-controller-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/leader_election_role_binding.yaml
+++ b/charts/payaza-operator/templates/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  name: payaza-controller-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: payaza-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.controllerManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/metrics_auth_role.yaml
+++ b/charts/payaza-operator/templates/rbac/metrics_auth_role.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.rbac.enable .Values.metrics.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payaza-controller-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/metrics_auth_role_binding.yaml
+++ b/charts/payaza-operator/templates/rbac/metrics_auth_role_binding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.enable .Values.metrics.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payaza-controller-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payaza-controller-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.controllerManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/metrics_reader_role.yaml
+++ b/charts/payaza-operator/templates/rbac/metrics_reader_role.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.rbac.enable .Values.metrics.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payaza-controller-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/payazaservice_admin_role.yaml
+++ b/charts/payaza-operator/templates/rbac/payazaservice_admin_role.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.enable }}
+# This rule is not used by the project payaza-controller itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over apps.payaza.africa.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payazaservice-admin-role
+rules:
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices/status
+  verbs:
+  - get
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/payazaservice_editor_role.yaml
+++ b/charts/payaza-operator/templates/rbac/payazaservice_editor_role.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.enable }}
+# This rule is not used by the project payaza-controller itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the apps.payaza.africa.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payazaservice-editor-role
+rules:
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices/status
+  verbs:
+  - get
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/payazaservice_viewer_role.yaml
+++ b/charts/payaza-operator/templates/rbac/payazaservice_viewer_role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.enable }}
+# This rule is not used by the project payaza-controller itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to apps.payaza.africa resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payazaservice-viewer-role
+rules:
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices/status
+  verbs:
+  - get
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/role.yaml
+++ b/charts/payaza-operator/templates/rbac/role.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.rbac.enable }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payaza-controller-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.payaza.africa
+  resources:
+  - payazaservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/role_binding.yaml
+++ b/charts/payaza-operator/templates/rbac/role_binding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: payaza-controller-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payaza-controller-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.controllerManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/payaza-operator/templates/rbac/service_account.yaml
+++ b/charts/payaza-operator/templates/rbac/service_account.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
+  name: {{ .Values.controllerManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/payaza-operator/values.yaml
+++ b/charts/payaza-operator/values.yaml
@@ -1,0 +1,76 @@
+# [MANAGER]: Manager Deployment Configurations
+controllerManager:
+  replicas: 1
+  container:
+    image:
+      repository: 823343520581.dkr.ecr.eu-west-2.amazonaws.com/payaza-controller
+      tag: 1.0.0
+    args:
+      - "--leader-elect"
+      - "--metrics-bind-address=:8443"
+      - "--health-probe-bind-address=:8081"
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+    livenessProbe:
+      initialDelaySeconds: 15
+      periodSeconds: 20
+      httpGet:
+        path: /healthz
+        port: 8081
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      httpGet:
+        path: /readyz
+        port: 8081
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - "ALL"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  terminationGracePeriodSeconds: 10
+  serviceAccountName: payaza-controller-controller-manager
+
+# [RBAC]: To enable RBAC (Permissions) configurations
+rbac:
+  enable: true
+
+# [CRDs]: To enable the CRDs
+crd:
+  # This option determines whether the CRDs are included
+  # in the installation process.
+  enable: true
+
+  # Enabling this option adds the "helm.sh/resource-policy": keep
+  # annotation to the CRD, ensuring it remains installed even when
+  # the Helm release is uninstalled.
+  # NOTE: Removing the CRDs will also remove all cert-manager CR(s)
+  # (Certificates, Issuers, ...) due to garbage collection.
+  keep: true
+
+# [METRICS]: Set to true to generate manifests for exporting metrics.
+# To disable metrics export set false, and ensure that the
+# ControllerManager argument "--metrics-bind-address=:8443" is removed.
+metrics:
+  enable: true
+
+# [PROMETHEUS]: To enable a ServiceMonitor to export metrics to Prometheus set true
+prometheus:
+  enable: false
+
+# [CERT-MANAGER]: To enable cert-manager injection to webhooks set true
+certmanager:
+  enable: false
+
+# [NETWORK POLICIES]: To enable NetworkPolicies set true
+networkPolicy:
+  enable: false


### PR DESCRIPTION
- Created .helmignore to exclude unnecessary files during packaging.
- Added Chart.yaml with metadata for the payaza-controller Helm chart.
- Implemented _helpers.tpl for reusable template functions.
- Defined cert-manager issuer and certificate resources in certificate.yaml.
- Created CustomResourceDefinition for PayazaService in apps.payaza.africa.
- Developed manager deployment configuration in manager.yaml.
- Added metrics service definition in metrics-service.yaml.
- Implemented network policy to allow metrics traffic in allow-metrics-traffic.yaml.
- Integrated Prometheus ServiceMonitor for metrics collection in monitor.yaml.
- Established RBAC roles and bindings for leader election and metrics access.
- Configured service account for the controller manager in service_account.yaml.
- Updated values.yaml with default configurations for the controller manager, RBAC, CRDs, metrics, and cert-manager.