### PR TITLE
Rename resources for consistency in payaza-controller-manager

### DIFF
--- a/charts/payaza-controller/templates/manager/manager.yaml
+++ b/charts/payaza-controller/templates/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: payaza-controller-controller-manager
+  name: payaza-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/charts/payaza-controller/templates/metrics/metrics-service.yaml
+++ b/charts/payaza-controller/templates/metrics/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: payaza-controller-controller-manager-metrics-service
+  name: payaza-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/charts/payaza-controller/templates/prometheus/monitor.yaml
+++ b/charts/payaza-controller/templates/prometheus/monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
     control-plane: controller-manager
-  name: payaza-controller-controller-manager-metrics-monitor
+  name: payaza-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
@@ -16,7 +16,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{- if .Values.certmanager.enable }}
-        serverName: payaza-controller-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+        serverName: payaza-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
         # Apply secure TLS configuration with cert-manager
         insecureSkipVerify: false
         ca:

--- a/charts/payaza-controller/values.yaml
+++ b/charts/payaza-controller/values.yaml
@@ -38,7 +38,7 @@ controllerManager:
     seccompProfile:
       type: RuntimeDefault
   terminationGracePeriodSeconds: 10
-  serviceAccountName: payaza-controller-controller-manager
+  serviceAccountName: payaza-controller-manager
 
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:


### PR DESCRIPTION
Update resource names to use the 'payaza-controller-manager' prefix for better consistency and clarity across the deployment, service, and ServiceMonitor configurations. Adjust the service account name in values.yaml accordingly.