### PR TITLE
Add Helm chart for payaza-controller with RBAC and metrics support

### DIFF
--- a/charts/payaza-controller/Chart.yaml
+++ b/charts/payaza-controller/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: payaza-controller
 description: A Helm chart to distribute the project payaza-controller
 type: application
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.0.2
+appVersion: "1.0.2"
 icon: "https://payaza.africa/favicon.ico"

--- a/charts/payaza-controller/templates/certmanager/certificate.yaml
+++ b/charts/payaza-controller/templates/certmanager/certificate.yaml
@@ -25,9 +25,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-    - payaza-controller.{{ .Release.Namespace }}.svc
-    - payaza-controller.{{ .Release.Namespace }}.svc.cluster.local
-    - payaza-controller-metrics-service.{{ .Release.Namespace }}.svc
+    - payaza-.{{ .Release.Namespace }}.svc
+    - payaza-.{{ .Release.Namespace }}.svc.cluster.local
+    - payaza--metrics-service.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/charts/payaza-controller/templates/manager/manager.yaml
+++ b/charts/payaza-controller/templates/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: payaza-controller-controller-manager
+  name: payaza-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/charts/payaza-controller/templates/metrics/metrics-service.yaml
+++ b/charts/payaza-controller/templates/metrics/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: payaza-controller-controller-manager-metrics-service
+  name: payaza-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/charts/payaza-controller/templates/prometheus/monitor.yaml
+++ b/charts/payaza-controller/templates/prometheus/monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
     control-plane: controller-manager
-  name: payaza-controller-controller-manager-metrics-monitor
+  name: payaza-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
@@ -16,7 +16,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{- if .Values.certmanager.enable }}
-        serverName: payaza-controller-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+        serverName: payaza-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
         # Apply secure TLS configuration with cert-manager
         insecureSkipVerify: false
         ca:

--- a/charts/payaza-controller/values.yaml
+++ b/charts/payaza-controller/values.yaml
@@ -4,7 +4,7 @@ controllerManager:
   container:
     image:
       repository: 823343520581.dkr.ecr.eu-west-2.amazonaws.com/payaza-controller
-      tag: 1.0.1
+      tag: 1.0.2
     args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"

--- a/charts/payaza-controller/values.yaml
+++ b/charts/payaza-controller/values.yaml
@@ -38,7 +38,7 @@ controllerManager:
     seccompProfile:
       type: RuntimeDefault
   terminationGracePeriodSeconds: 10
-  serviceAccountName: payaza-controller-controller-manager
+  serviceAccountName: payaza-controller-manager
 
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:


### PR DESCRIPTION
Introduce the initial Helm chart for the payaza-controller, including RBAC configurations, CustomResourceDefinitions, and metrics integration. Migrate RBAC resources from the payaza-operator chart and ensure consistent naming across resources. Update the chart version and enhance permissions for better functionality.