### PR TITLE
Update payaza-controller Helm chart to version 1.0.3

### DIFF
--- a/charts/payaza-controller/Chart.yaml
+++ b/charts/payaza-controller/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: payaza-controller
 description: A Helm chart to distribute the project payaza-controller
 type: application
-version: 1.0.2
-appVersion: "1.0.2"
+version: 1.0.3
+appVersion: "1.0.3"
 icon: "https://payaza.africa/favicon.ico"

--- a/charts/payaza-controller/templates/certmanager/certificate.yaml
+++ b/charts/payaza-controller/templates/certmanager/certificate.yaml
@@ -27,7 +27,7 @@ spec:
   dnsNames:
     - payaza-.{{ .Release.Namespace }}.svc
     - payaza-.{{ .Release.Namespace }}.svc.cluster.local
-    - payaza--metrics-service.{{ .Release.Namespace }}.svc
+    - payaza-controller-metrics-service.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/charts/payaza-controller/templates/rbac/role.yaml
+++ b/charts/payaza-controller/templates/rbac/role.yaml
@@ -12,17 +12,6 @@ rules:
   resources:
   - configmaps
   - secrets
-  verbs:
-  - create
-  - 'delete # Added create/update/patch/delete'
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   - services
   verbs:

--- a/charts/payaza-controller/values.yaml
+++ b/charts/payaza-controller/values.yaml
@@ -4,7 +4,7 @@ controllerManager:
   container:
     image:
       repository: 823343520581.dkr.ecr.eu-west-2.amazonaws.com/payaza-controller
-      tag: 1.0.2
+      tag: 1.0.3
     args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
Increment the Helm chart version and appVersion, rename the metrics service, remove unnecessary RBAC verbs, and update the image tag.