### PR TITLE
Update payaza-operator Helm chart to version 1.0.1

### DIFF
--- a/charts/payaza-operator/Chart.yaml
+++ b/charts/payaza-operator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: payaza-operator
 description: A Helm chart to distribute the project payaza
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.1
+appVersion: "1.0.1"
 icon: "https://payaza.africa/favicon.ico"

--- a/charts/payaza-operator/values.yaml
+++ b/charts/payaza-operator/values.yaml
@@ -4,7 +4,7 @@ controllerManager:
   container:
     image:
       repository: 823343520581.dkr.ecr.eu-west-2.amazonaws.com/payaza-operator
-      tag: latest
+      tag: 1.0.1
     args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
Increment the version and appVersion in the Helm chart and update the image tag to match the new version.