### PR TITLE
add additionalVolumeMounts, additionalVolumes, and crypto_secret ExternalSecret support to payaza-v2; bump to 1.1.0

### DIFF
--- a/charts/payaza-v2/Chart.yaml
+++ b/charts/payaza-v2/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/payaza-v2/templates/deployment.yaml
+++ b/charts/payaza-v2/templates/deployment.yaml
@@ -47,10 +47,15 @@ spec:
           imagePullPolicy: {{ .Values.deployment.pullPolicy }}
           ports:
           - containerPort: {{ .Values.deployment.port }}
-          {{- if .Values.volume.bind }}
+          {{- if or .Values.volume.bind .Values.additionalVolumeMounts }}
           volumeMounts:
+          {{- if .Values.volume.bind }}
           - name: {{ .Values.deployment.name | quote }}
             mountPath: {{ .Values.volume.path }}
+          {{- end }}
+          {{- if .Values.additionalVolumeMounts }}
+          {{- toYaml .Values.additionalVolumeMounts | nindent 10 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enable }}
           readinessProbe:
@@ -104,12 +109,17 @@ spec:
               cpu: "2"
               memory: "2Gi"
           {{- end }}
-      {{- if .Values.pvc.create }}
+      {{- if or .Values.pvc.create .Values.additionalVolumes }}
       volumes:
+      {{- if .Values.pvc.create }}
       - name: {{ .Values.deployment.name | quote }}
         persistentVolumeClaim:
           claimName: {{ .Values.pvc.name }}
-      {{- end}}
+      {{- end }}
+      {{- if .Values.additionalVolumes }}
+      {{- toYaml .Values.additionalVolumes | nindent 6 }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.environment }}
       nodeSelector:
         environment: {{ .Values.environment.name | quote }}

--- a/charts/payaza-v2/templates/external_secrets.yaml
+++ b/charts/payaza-v2/templates/external_secrets.yaml
@@ -15,3 +15,21 @@ spec:
     - extract:
         key: {{ .Values.env.external_secret.secretManagerRef}}
 {{- end }}
+{{- if .Values.env.crypto_secret.create }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.deployment.name }}-crypto-keys
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.env.crypto_secret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.env.crypto_secret.secretStoreName }}
+    kind: SecretStore
+  target:
+    name: {{ .Values.env.crypto_secret.secretName }}
+  dataFrom:
+    - extract:
+        key: {{ .Values.env.crypto_secret.secretManagerRef }}
+{{- end }}

--- a/charts/payaza-v2/values.yaml
+++ b/charts/payaza-v2/values.yaml
@@ -105,6 +105,13 @@ env:
     secretName: my-secret  # Name of the target secret to create
     secretManagerRef: payaza-prod  # Name of the secret on secret manager (payaza-prod)
 
+  crypto_secret:
+    create: false  # Set to true to create a separate ExternalSecret for file-mounted secrets (e.g. PEM keys)
+    refreshInterval: 1h
+    secretStoreName: aws-secretsmanager
+    secretName: my-crypto-secret
+    secretManagerRef: my-aws-crypto-secret-path
+
 additionalSecrets:
   []
   # - secretRef:
@@ -114,6 +121,21 @@ additionalConfigs:
   []
   # - configMapRef:
   #     name:  existing-configMap-name
+
+additionalVolumeMounts:
+  []
+  # - name: crypto-keys
+  #   mountPath: /etc/myapp/keys
+  #   readOnly: true
+
+additionalVolumes:
+  []
+  # - name: crypto-keys
+  #   secret:
+  #     secretName: my-crypto-secret
+  #     items:
+  #       - key: bank_public.pem
+  #         path: bank_public.pem
 
 # autoscaling
 # This is used for scaling pods horizontally.


### PR DESCRIPTION
# Add file-based secret mounting support to payaza-v2 chart (v1.1.0)

## What Changed

### `charts/payaza-v2/Chart.yaml`
- Bumped version from 1.0.3 to 1.1.0

### `charts/payaza-v2/templates/deployment.yaml`
- Added `additionalVolumeMounts` passthrough block inside container which merges with existing `volume.bind` mount using an `or` gate
- Added `additionalVolumes` passthrough block at pod level which merges with existing `pvc.create` volume using an `or` gate
- Both use `toYaml | nindent` passthrough, consistent with the existing `additionalSecrets` / `additionalConfigs` pattern

### `charts/payaza-v2/templates/external_secrets.yaml`
- Added a second `ExternalSecret` block gated by `env.crypto_secret.create` which creates a separate secret for file-mounted credentials (e.g. PEM keys), independent of the main app secret

### `charts/payaza-v2/values.yaml`
- Added `env.crypto_secret` block (mirrors existing `env.external_secret` structure)
- Added `additionalVolumeMounts: []` 
- Added `additionalVolumes: []` 

## Why

Services that use RSA key files (e.g. `firstbank-routing-svc`) cannot consume PEM keys as env vars as Spring loads them as `Resource` objects via `file:` URIs. The chart previously had no way to mount secrets as files. This adds that capability as a generic, reusable passthrough so any service can opt in without needing a dedicated chart.

<img width="1476" height="519" alt="Screenshot 2026-06-23 at 12 45 23 AM" src="https://github.com/user-attachments/assets/55896bcd-192a-488a-b8c0-590d36ceee04" />
<img width="1471" height="646" alt="Screenshot 2026-06-23 at 12 48 33 AM" src="https://github.com/user-attachments/assets/26fb40bd-f7ed-41a4-a8bc-3552c75578e1" />
<img width="1116" height="629" alt="Screenshot 2026-06-23 at 12 52 38 AM" src="https://github.com/user-attachments/assets/538cf279-1383-4d5f-968d-92fb03e770c1" />
<img width="1344" height="573" alt="Screenshot 2026-06-23 at 12 54 42 AM" src="https://github.com/user-attachments/assets/96af3f89-8d81-449d-aa20-c3a3042f29cf" />
